### PR TITLE
Added Routing + a side quest of dark mode toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <div id="root" class="w-screen h-screen flex container flex-col place-items-center">
+  <div id="root" class="w-dvh min-h-screen flex flex-col place-items-center">
   </div>
   <script type="module" src="/src/main.tsx"></script>
 </body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "purrcast-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-navigation-menu": "^1.1.4",
@@ -852,6 +853,40 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.1.tgz",
+      "integrity": "sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -1018,6 +1053,29 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
+      "integrity": "sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
@@ -1122,6 +1180,77 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.0.6.tgz",
+      "integrity": "sha512-i6TuFOoWmLWq+M/eCLGd/bQ2HfAX1RJgvrBQ6AQLmzfvsLdefxbWu8G9zczcPFfcSPehz9GcpF6K9QYreFV8hA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-menu": "2.0.6",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+      "integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
+      "integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-icons": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.0.tgz",
@@ -1155,6 +1284,46 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.0.6.tgz",
+      "integrity": "sha512-BVkFLS+bUC8HcImkRKPSiVumA1VPOOEC5WBMiT+QAVsPzW1FJzI9KnqgGxVDPBcql5xXrHkD3JOVoXWEXD8SYA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1207,6 +1376,61 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.3.tgz",
+      "integrity": "sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-rect": "1.0.1",
+        "@radix-ui/react-use-size": "1.0.1",
+        "@radix-ui/rect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+      "integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-presence": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
@@ -1238,6 +1462,37 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1382,6 +1637,42 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz",
+      "integrity": "sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz",
+      "integrity": "sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-visually-hidden": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
@@ -1403,6 +1694,14 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.1.tgz",
+      "integrity": "sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1954,6 +2253,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2302,6 +2612,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2875,6 +3190,14 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3010,6 +3333,14 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3762,6 +4093,73 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.3",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4273,6 +4671,11 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4353,6 +4756,47 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.1.tgz",
+      "integrity": "sha512-Lg4Vx1XZQauB42Hw3kK7JM6yjVjgFmFC5/Ab797s79aARomD2nEErc4mCgM8EZrARLmmbWpi5DGCadmK50DcAQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-navigation-menu": "^1.1.4",

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -2,9 +2,14 @@ import Home from "@/components/Home/Home";
 import { NavMenu } from "@/components/NavMeun/NavMenu";
 import NewPostForm from "@/components/NewPostForm/NewPostForm";
 import { Route } from "wouter";
+import Login from "./components/Login/Login";
 import Post from "./components/Post/Post";
+import PostsPreview from "./components/PostsPreview/PostsPreview";
+import Profile from "./components/Profile/Profile";
+import Test from "./components/Test/Test";
 import { ThemeProvider } from "./components/ThemeProvider/ThemeProvider";
 import { ModeToggle } from "./components/ThemeToggle/ThemeToggle";
+import faq from "./components/faq/faq";
 
 function App() {
   return (
@@ -17,16 +22,24 @@ function App() {
     */
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <header className='sticky top-0 z-50 w-screen border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'>
-        <div className="w-full flex h-14 max-w-screen-2xl items-center p-10 justify-between">
+        <div className="w-full flex h-14  items-center p-10 justify-between">
           <NavMenu />
           <ModeToggle />
         </div>
       </header>
-      <section id="main-content" className="w-full max-w-screen-2xl flex place-content-center my-20">
+      <section id="main-content" className="w-full h-full max-w-screen-2xl flex place-content-center my-20">
         <Route path="/" component={Home} />
+        <Route path="/faq" component={faq} />
+
+        <Route path="/login" component={Login} />
+
         <Route path="/create-post" component={NewPostForm} />
         <Route path="/post/:post_id" component={Post} />
 
+        <Route path="/profile" component={Profile} />
+        <Route path="/profile/posts" component={PostsPreview} />
+
+        <Route path="/testing" component={Test} />
       </section>
     </ThemeProvider>
   )

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,7 +1,7 @@
-import { Route } from "wouter";
 import Home from "@/components/Home/Home";
-import NewPostForm from "@/components/NewPostForm/NewPostForm";
 import { NavMenu } from "@/components/NavMeun/NavMenu";
+import NewPostForm from "@/components/NewPostForm/NewPostForm";
+import { Route } from "wouter";
 import Post from "./components/Post/Post";
 
 function App() {
@@ -16,7 +16,7 @@ function App() {
     <>
       <header className='sticky top-0 z-50 w-screen border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'>
         <div className="container flex h-14 max-w-screen-2xl items-center">
-          <NavMenu className='flex flex-1 items-center justify-between space-x-2 md:justify-end' />
+          <NavMenu />
         </div>
       </header>
       <Route path="/" component={Home} />

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -10,6 +10,7 @@ import Test from "./components/Test/Test";
 import { ThemeProvider } from "./components/ThemeProvider/ThemeProvider";
 import { ModeToggle } from "./components/ThemeToggle/ThemeToggle";
 import faq from "./components/faq/faq";
+import UserPostsHistory from "./components/UserPostsHistory/UserPostsHistory";
 
 function App() {
   return (
@@ -21,13 +22,13 @@ function App() {
       Do so by utilizing props or auth context
     */
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-      <header className='sticky top-0 z-50 w-screen border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'>
+      <header className='w-full sticky top-0 z-50 border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'>
         <div className="w-full flex h-14  items-center p-10 justify-between">
           <NavMenu />
           <ModeToggle />
         </div>
       </header>
-      <section id="main-content" className="w-full h-full max-w-screen-2xl flex place-content-center my-20">
+      <section id="main-content" className="w-full h-full max-w-screen-2xl flex relative flex-grow place-items-center justify-center my-10">
         <Route path="/" component={Home} />
         <Route path="/faq" component={faq} />
 
@@ -37,7 +38,7 @@ function App() {
         <Route path="/post/:post_id" component={Post} />
 
         <Route path="/profile" component={Profile} />
-        <Route path="/profile/posts" component={PostsPreview} />
+        <Route path="/profile/posts" component={UserPostsHistory} />
 
         <Route path="/testing" component={Test} />
       </section>

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -3,6 +3,8 @@ import { NavMenu } from "@/components/NavMeun/NavMenu";
 import NewPostForm from "@/components/NewPostForm/NewPostForm";
 import { Route } from "wouter";
 import Post from "./components/Post/Post";
+import { ThemeProvider } from "./components/ThemeProvider/ThemeProvider";
+import { ModeToggle } from "./components/ThemeToggle/ThemeToggle";
 
 function App() {
   return (
@@ -13,17 +15,20 @@ function App() {
 
       Do so by utilizing props or auth context
     */
-    <>
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <header className='sticky top-0 z-50 w-screen border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'>
-        <div className="container flex h-14 max-w-screen-2xl items-center">
+        <div className="w-full flex h-14 max-w-screen-2xl items-center p-10 justify-between">
           <NavMenu />
+          <ModeToggle />
         </div>
       </header>
-      <Route path="/" component={Home} />
-      <Route path="/create-post" component={NewPostForm} />
-      <Route path="/post/:post_id" component={Post} />
+      <section id="main-content" className="w-full max-w-screen-2xl flex place-content-center my-20">
+        <Route path="/" component={Home} />
+        <Route path="/create-post" component={NewPostForm} />
+        <Route path="/post/:post_id" component={Post} />
 
-    </>
+      </section>
+    </ThemeProvider>
   )
 }
 

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,52 +1,28 @@
-import { NavMenu } from './components/NavMeun/NavMenu';
-import PostsPreview from './components/PostsPreview/PostsPreview';
-import { Button } from './components/ui/button';
+import { Route } from "wouter";
+import Home from "@/components/Home/Home";
+import NewPostForm from "@/components/NewPostForm/NewPostForm";
+import { NavMenu } from "@/components/NavMeun/NavMenu";
+import Post from "./components/Post/Post";
 
 function App() {
   return (
+    /*
+    TODO:
+      If user is not logged in, give them the generic homepage
+      Else, if they are logged in, give them a more customized homepage
+
+      Do so by utilizing props or auth context
+    */
     <>
       <header className='sticky top-0 z-50 w-screen border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'>
         <div className="container flex h-14 max-w-screen-2xl items-center">
-          {/* <a href="/" className="mr-6 flex items-center space-x-2">
-            <img src="/purrcast.gif" alt="Purrcast Logo" className="h-[50px] w-[50px] rotate-180" />
-          </a> */}
           <NavMenu className='flex flex-1 items-center justify-between space-x-2 md:justify-end' />
         </div>
       </header>
+      <Route path="/" component={Home} />
+      <Route path="/create-post" component={NewPostForm} />
+      <Route path="/post/:post_id" component={Post} />
 
-      <main className="flex flex-col flex-auto flex-wrap justify-center w-1/2 md:w-3/5 max-w-screen-lg space-y-10 py-6 lg:py-8 ">
-        <section id="splash-intro" className="w-full">
-          <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl break-words">
-            Welcome to {(import.meta.env.PROD) ? "Purrcast" : "Purrcast Test Feed"}!
-          </h1>
-          <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
-            An old shriveled soothsayer once said:
-            <blockquote className="mt-6 border-l-2 pl-6 italic break-words">
-              If your cat lays on it's head, there is rain up ahead.
-            </blockquote>
-          </p>
-          <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
-            I took that very personally and so Purrcast was built to act as a centralized place for you to post and look at photos of peoples cats in your area to determine if it's going to rain soon or maybe just drizzle.
-          </p>
-
-          <div className='size-fit mt-8 p-[1px] rounded-md bg-blue-500 shadow-md hover:bg-slate-700'>
-            <Button className="p-6 text-lg bg-blue-500 border-solid border-4 border-blue-200 hover:border-blue-500 hover:bg-blue-200 hover:text-slate-700">Post a Cat!</Button>
-          </div>
-
-          {/* <Button asChild>
-            <Link href="/create-post">Post a Cat!</Link>
-          </Button> */}
-
-
-        </section>
-
-        <section id="splash-prev-posts" className="w-full">
-          <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
-            Posts being made by other users
-          </h2>
-          <PostsPreview />
-        </section>
-      </main>
     </>
   )
 }

--- a/frontend/src/components/Home/Home.tsx
+++ b/frontend/src/components/Home/Home.tsx
@@ -1,0 +1,41 @@
+import PostsPreview from '@/components/PostsPreview/PostsPreview';
+import { Button } from '@/components/ui/button';
+import { Link } from 'wouter';
+
+export default function Home() {
+    return (
+        <>
+            <main className="flex flex-col flex-auto flex-wrap justify-center w-1/2 md:w-3/5 max-w-screen-lg space-y-10 py-6 lg:py-8 ">
+                <section id="splash-intro" className="w-full">
+                    <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl break-words">
+                        Welcome to {(import.meta.env.PROD) ? "Purrcast" : "Purrcast Test Feed"}!
+                    </h1>
+                    <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
+                        An old shriveled soothsayer once said:
+                    </p>
+                    <blockquote className="mt-6 border-l-2 pl-6 italic break-words">
+                        If your cat lays on it's head, there is rain up ahead.
+                    </blockquote>
+                    <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
+                        I took that very personally and so Purrcast was built to act as a centralized place for you to post and look at photos of peoples cats in your area to determine if it's going to rain soon or maybe just drizzle.
+                    </p>
+
+                    <div className='w-fit h-fit mt-8 p-[1px] rounded-md bg-blue-500 shadow-md hover:bg-slate-700'>
+                        <Button className="p-6 text-lg bg-blue-500 border-solid border-4 border-blue-200 hover:border-blue-500 hover:bg-blue-200 hover:text-slate-700">
+                            <Link href="/create-post">Post a Cat!</Link>
+                        </Button>
+                    </div>
+                </section>
+
+                <section id="splash-prev-posts" className="w-full">
+                    <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
+                        Posts being made by other users
+                    </h2>
+                    <PostsPreview />
+                </section>
+            </main>
+        </>
+
+    )
+
+}

--- a/frontend/src/components/Home/Home.tsx
+++ b/frontend/src/components/Home/Home.tsx
@@ -20,10 +20,19 @@ export default function Home() {
                         I took that very personally and so Purrcast was built to act as a centralized place for you to post and look at photos of peoples cats in your area to determine if it's going to rain soon or maybe just drizzle.
                     </p>
 
-                    <div className='w-fit h-fit mt-8 p-[1px] rounded-md bg-blue-500 shadow-md hover:bg-slate-700'>
-                        <Button className="p-6 text-lg bg-blue-500 border-solid border-4 border-blue-200 hover:border-blue-500 hover:bg-blue-200 hover:text-slate-700">
-                            <Link href="/create-post">Post a Cat!</Link>
-                        </Button>
+                    <div id="splash-buttons" className="flex flex-row justify-start w-full mt-8 space-x-4">
+                        {/* TODO: maybe make your buttons into a special class so you can extend the colors to use more than just hte primary and secondary color vars defined in the globals.css */}
+                        <div className='w-fit h-fit mt-8 p-[1px] rounded-md bg-blue-500 shadow-md hover:bg-slate-700'>
+                            <Button className="p-6 text-lg bg-blue-500 border-solid border-4 border-blue-200 hover:border-blue-500 hover:bg-blue-200 hover:text-slate-700">
+                                <Link href="/create-post">Post a Cat!</Link>
+                            </Button>
+                        </div>
+                        <div className='w-fit h-fit mt-8 p-[1px] rounded-md bg-purple-500 shadow-md hover:bg-slate-700'>
+
+                            <Button className="p-6 text-lg bg-purple-500 border-solid border-4 border-purple-200 hover:border-purple-500 hover:bg-purple-200 hover:text-slate-700">
+                                <Link href="/faq">What Are You Talking About?</Link>
+                            </Button>
+                        </div>
                     </div>
                 </section>
 

--- a/frontend/src/components/Home/Home.tsx
+++ b/frontend/src/components/Home/Home.tsx
@@ -5,7 +5,7 @@ import { Link } from 'wouter';
 export default function Home() {
     return (
         <>
-            <main className="flex flex-col flex-auto flex-wrap justify-center w-1/2 md:w-3/5 max-w-screen-lg space-y-10 py-6 lg:py-8 ">
+            <main className="flex flex-col flex-auto flex-wrap justify-center w-1/2 md:w-3/5 max-w-screen-lg space-y-10 *:p-5">
                 <section id="splash-intro" className="w-full">
                     <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl break-words">
                         Welcome to {(import.meta.env.PROD) ? "Purrcast" : "Purrcast Test Feed"}!

--- a/frontend/src/components/Home/Home.tsx
+++ b/frontend/src/components/Home/Home.tsx
@@ -5,7 +5,7 @@ import { Link } from 'wouter';
 export default function Home() {
     return (
         <>
-            <main className="flex flex-col flex-auto flex-wrap justify-center w-1/2 md:w-3/5 max-w-screen-lg space-y-10 *:p-5">
+            <main className="flex flex-col flex-auto place-items-center w-1/2 md:w-3/5 max-w-screen-lg space-y-10 *:p-5">
                 <section id="splash-intro" className="w-full">
                     <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl break-words">
                         Welcome to {(import.meta.env.PROD) ? "Purrcast" : "Purrcast Test Feed"}!

--- a/frontend/src/components/Login/Login.tsx
+++ b/frontend/src/components/Login/Login.tsx
@@ -1,0 +1,16 @@
+export default function Login() {
+  //do some supabase oauth stuff
+
+  //populate some auth context???
+  return (
+    <>
+      <div>
+        <h1>Login</h1>
+        <p>Log in with your favorite social media platform</p>
+        <button>Log in with Google</button>
+        <button>Log in with Facebook</button>
+        <button>Log in with Twitter</button>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/NavMeun/NavMenu.tsx
+++ b/frontend/src/components/NavMeun/NavMenu.tsx
@@ -11,6 +11,7 @@ import {
     NavigationMenuTrigger,
     navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu"
+import { Link } from "wouter";
 
 const components: { title: string; href: string; description: string }[] = [
     {
@@ -33,31 +34,30 @@ const components: { title: string; href: string; description: string }[] = [
     }
 ]
 
-export function NavMenu({ className = '' }) {
+export function NavMenu() {
     return (
         <div>
             <NavigationMenu>
                 <NavigationMenuList>
-                    {/* <NavigationMenuItem>
-                        <a href="/profile">
+                    <NavigationMenuItem>
+                        <Link href="/">
                             <NavigationMenuLink className={navigationMenuTriggerStyle()}>
                                 Home
                             </NavigationMenuLink>
-                        </a>
-                    </NavigationMenuItem> */}
+                        </Link>
+                    </NavigationMenuItem>
 
                     <NavigationMenuItem className="m-0">
                         <NavigationMenuTrigger>Profile</NavigationMenuTrigger>
                         <NavigationMenuContent>
                             <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px] ">
                                 {components.map((component) => (
-                                    <ListItem
-                                        key={component.title}
-                                        title={component.title}
-                                        href={component.href}
-                                    >
-                                        {component.description}
-                                    </ListItem>
+                                    <Link key={component.title}
+                                        href={component.href}>
+                                        <ListItem title={component.title}>
+                                            {component.description}
+                                        </ListItem>
+                                    </Link>
                                 ))}
                             </ul>
                         </NavigationMenuContent>

--- a/frontend/src/components/NavMeun/NavMenu.tsx
+++ b/frontend/src/components/NavMeun/NavMenu.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useState, forwardRef, ComponentPropsWithoutRef, ElementRef } from "react";
 
 import { cn } from "@/lib/utils";
 // import { Icons } from "@/components/icons"
@@ -35,6 +35,9 @@ const components: { title: string; href: string; description: string }[] = [
 ]
 
 export function NavMenu() {
+    // TODO: replace with true auth state, using auth context perhaps.
+    const [loggedIn] = useState(false);
+
     return (
         <div>
             <NavigationMenu className="flex flex-row w-full justify-between">
@@ -47,30 +50,40 @@ export function NavMenu() {
                         </Link>
                     </NavigationMenuItem>
 
-                    <NavigationMenuItem className="m-0">
-                        <NavigationMenuTrigger>Profile</NavigationMenuTrigger>
-                        <NavigationMenuContent>
-                            <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px] ">
-                                {components.map((component) => (
-                                    <Link key={component.title}
-                                        href={component.href}>
-                                        <ListItem title={component.title}>
-                                            {component.description}
-                                        </ListItem>
-                                    </Link>
-                                ))}
-                            </ul>
-                        </NavigationMenuContent>
-                    </NavigationMenuItem>
+                    {(loggedIn) ?
+                        <NavigationMenuItem className="m-0">
+                            <NavigationMenuTrigger>Profile</NavigationMenuTrigger>
+                            <NavigationMenuContent>
+                                <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px] ">
+                                    {components.map((component) => (
+                                        <Link key={component.title}
+                                            href={component.href}>
+                                            <ListItem title={component.title}>
+                                                {component.description}
+                                            </ListItem>
+                                        </Link>
+                                    ))}
+                                </ul>
+                            </NavigationMenuContent>
+                        </NavigationMenuItem>
+                        :
+                        <NavigationMenuItem>
+                            <Link href="/login">
+                                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                                    Log In
+                                </NavigationMenuLink>
+                            </Link>
+                        </NavigationMenuItem>
+                    }
                 </NavigationMenuList>
             </NavigationMenu>
         </div>
     )
 }
 
-const ListItem = React.forwardRef<
-    React.ElementRef<"a">,
-    React.ComponentPropsWithoutRef<"a">
+const ListItem = forwardRef<
+    ElementRef<"a">,
+    ComponentPropsWithoutRef<"a">
 >(({ className, title, children, ...props }, ref) => {
     return (
         <li>

--- a/frontend/src/components/NavMeun/NavMenu.tsx
+++ b/frontend/src/components/NavMeun/NavMenu.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 // import { Icons } from "@/components/icons"
 import {
     NavigationMenu,
@@ -10,7 +10,7 @@ import {
     NavigationMenuList,
     NavigationMenuTrigger,
     navigationMenuTriggerStyle,
-} from "@/components/ui/navigation-menu"
+} from "@/components/ui/navigation-menu";
 import { Link } from "wouter";
 
 const components: { title: string; href: string; description: string }[] = [
@@ -21,10 +21,10 @@ const components: { title: string; href: string; description: string }[] = [
             "Edit your profile information, including your name, email, and password.",
     },
     {
-        title: "Settings",
-        href: "/profile/settings",
+        title: "View Posts",
+        href: "/profile/posts",
         description:
-            "Manage your account settings, including your email, password, and security preferences.",
+            "View all of your posts and manage them from one place.",
     },
     {
         title: "Sign Out",
@@ -37,7 +37,7 @@ const components: { title: string; href: string; description: string }[] = [
 export function NavMenu() {
     return (
         <div>
-            <NavigationMenu>
+            <NavigationMenu className="flex flex-row w-full justify-between">
                 <NavigationMenuList>
                     <NavigationMenuItem>
                         <Link href="/">

--- a/frontend/src/components/NewPostForm/NewPostForm.tsx
+++ b/frontend/src/components/NewPostForm/NewPostForm.tsx
@@ -1,10 +1,11 @@
 import axios from "axios";
 import { useState } from "react";
+import { Redirect } from "wouter";
 
 export default function NewPostForm() {
     const [uploadError, setUploadError] = useState<string>("");
-
     const [postImage, setPostImage] = useState<File | null>();
+    const loggedIn = false;
 
     const handlePostSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -42,14 +43,20 @@ export default function NewPostForm() {
         setPostImage(extractedFile.files[0]);
     }
     return (
-        <div id="new-post-wrap">
-            <h3>Make a New Post</h3>
-            <p >Upload a photo of your cat!</p>
-            <form id="new-post-form" onSubmit={handlePostSubmit} encType='multipart/form-data'>
-                <input type="file" name="postImage" id="postImageFile" accept="image/*" onChange={(e) => handlePostChange(e)} />
-                <button type="submit">Share</button>
-            </form>
-        </div>
+        <>
+            {(!loggedIn) ?
+                (<Redirect to="/login" />)
+                :
+                <div id="new-post-wrap">
+                    <h3>Make a New Post</h3>
+                    <p >Upload a photo of your cat!</p>
+                    <form id="new-post-form" onSubmit={handlePostSubmit} encType='multipart/form-data'>
+                        <input type="file" name="postImage" id="postImageFile" accept="image/*" onChange={(e) => handlePostChange(e)} />
+                        <button type="submit">Share</button>
+                    </form>
+                </div>
+            }
+        </>
 
     )
 

--- a/frontend/src/components/Post/Post.tsx
+++ b/frontend/src/components/Post/Post.tsx
@@ -1,20 +1,24 @@
 import { ThumbsUp } from "lucide-react";
-import { Button } from "../ui/button";
 import { useState } from "react";
-import { Separator } from "../ui/separator";
+import { Button } from "../ui/button";
 
 export default function Post() {
-    const [postVotes, setPostVotes] = useState(100);
-    const [upVoteBarLength, setUpVoteBarLength] = useState("w-[100px]");
+    const [postVotes, setPostVotes] = useState<number>(0);
 
     const upVotePost = () => {
-        console.log("Upvoted Post");
-        setPostVotes(postVotes + 1);
+        setPostVotes(prevVotes => prevVotes + 1);
     }
 
     const getUpVoteBarLength = () => {
-        if (postVotes > 0 && postVotes < 100) {
-
+        console.log("getting upvoted shits")
+        if (postVotes >= 0 && postVotes <= 999) {
+            return "w-[100px]";
+        } else if (postVotes > 999 && postVotes <= 9999) {
+            return "w-[125px]";
+        } else if (postVotes > 9999 && postVotes <= 99999) {
+            return "w-[150px]";
+        } else {
+            return "w-[200px]";
         }
     }
 
@@ -35,7 +39,7 @@ export default function Post() {
 
                 {/* TODO: possibly move this out to be it's own component, so Post doesnt have to keep track up PostVote state? */}
                 <section className=" flex flex-row justify-center post-metrics border-slate-400 border-solid border-[1px] rounded-full p-1 hover:border-slate-800 hover:bg-secondary transition-all">
-                    <div className={`${upVoteBarLength} grid grid-cols-2 divide-x text-center`}>
+                    <div className={`${getUpVoteBarLength()} grid grid-cols-2 divide-x text-center`}>
                         <div>
                             <Button onClick={upVotePost} variant="ghost" className="p-2 m-0 rounded-full hover:bg-popover">
                                 <ThumbsUp className="size-5 " />

--- a/frontend/src/components/Post/Post.tsx
+++ b/frontend/src/components/Post/Post.tsx
@@ -1,0 +1,57 @@
+import { ThumbsUp } from "lucide-react";
+import { Button } from "../ui/button";
+import { useState } from "react";
+import { Separator } from "../ui/separator";
+
+export default function Post() {
+    const [postVotes, setPostVotes] = useState(100);
+    const [upVoteBarLength, setUpVoteBarLength] = useState("w-[100px]");
+
+    const upVotePost = () => {
+        console.log("Upvoted Post");
+        setPostVotes(postVotes + 1);
+    }
+
+    const getUpVoteBarLength = () => {
+        if (postVotes > 0 && postVotes < 100) {
+
+        }
+    }
+
+    return (
+        <div className="flex flex-col w-full h-full place-content-center place-items-center">
+            <article className="flex flex-col size-screen place-items-center">
+                <section className="post-img w-3/4 p-4">
+                    <img src="https://source.unsplash.com/random/350x350" alt="Random Image" className="w-full h-full object-cover rounded-md" />
+                </section>
+                <section className="post-details text-center p-4">
+                    <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight place-item-end">
+                        Post by JaJa
+                    </h3>
+                    <p className="leading-7 [&:not(:first-child)]:mt-1 place-item-start">
+                        Corvallis, OR
+                    </p>
+                </section>
+
+                {/* TODO: possibly move this out to be it's own component, so Post doesnt have to keep track up PostVote state? */}
+                <section className=" flex flex-row justify-center post-metrics border-slate-400 border-solid border-[1px] rounded-full p-1 hover:border-slate-800 hover:bg-secondary transition-all">
+                    <div className={`${upVoteBarLength} grid grid-cols-2 divide-x text-center`}>
+                        <div>
+                            <Button onClick={upVotePost} variant="ghost" className="p-2 m-0 rounded-full hover:bg-popover">
+                                <ThumbsUp className="size-5 " />
+                            </Button>
+                        </div>
+                        {/* <Separator orientation="vertical" className="h-full -mx-95" /> */}
+                        <div className="flex flex-col justify-center place-items-center">
+                            <p className="text-xl text-center font-semibold tracking-tight">
+                                {postVotes}
+                            </p>
+                        </div>
+                    </div>
+                </section>
+
+            </article>
+        </div>
+    )
+
+}

--- a/frontend/src/components/PostPreviewCard/PostPreviewCard.tsx
+++ b/frontend/src/components/PostPreviewCard/PostPreviewCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardDescription, CardFooter, CardTitle } from "@/components/ui/card";
 import { Post } from "@/types/Post";
 import SkeletonPreviewCard from "../SkeletonPreviewCard/SkeletonPreviewCard";
+import { Link } from "wouter";
 
 interface PostPreviewCardProps {
     post?: Post;
@@ -27,7 +28,7 @@ function RealCard() {
 
 export default function PostPreviewCard({ post = {} as Post, skeleton = true }: PostPreviewCardProps) {
     return (
-        <a href={`/post/${post.id}`} className="w-full h-full">
+        <Link href={`/post/${post.id}`} className="w-full h-full">
             <Card className="hover:bg-muted cursor-pointer transition-colors h-full">
                 {
                     (!skeleton) ? (
@@ -37,7 +38,7 @@ export default function PostPreviewCard({ post = {} as Post, skeleton = true }: 
                     )
                 }
             </Card>
-        </a >
+        </Link>
 
     );
 }

--- a/frontend/src/components/PostPreviewCard/PostPreviewCard.tsx
+++ b/frontend/src/components/PostPreviewCard/PostPreviewCard.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardDescription, CardFooter, CardTitle } from "@/components/ui/card";
 import { Post } from "@/types/Post";
-import SkeletonPreviewCard from "../SkeletonPreviewCard/SkeletonPreviewCard";
 import { Link } from "wouter";
+import SkeletonPreviewCard from "../SkeletonPreviewCard/SkeletonPreviewCard";
 
 interface PostPreviewCardProps {
     post?: Post;
@@ -14,7 +14,6 @@ function RealCard() {
             <CardContent className="p-5">
                 <img loading="lazy" src="https://source.unsplash.com/random/350x350" alt="Random Image" className="w-full h-full object-cover rounded-sm" />
             </CardContent>
-
             <CardFooter className="flex flex-col flex-auto text-left pb-5">
                 <CardTitle>Posted by Jaja</CardTitle>
                 <CardDescription>Corvallis, OR</CardDescription>
@@ -28,17 +27,18 @@ function RealCard() {
 
 export default function PostPreviewCard({ post = {} as Post, skeleton = true }: PostPreviewCardProps) {
     return (
-        <Link href={`/post/${post.id}`} className="w-full h-full">
-            <Card className="hover:bg-muted cursor-pointer transition-colors h-full">
-                {
-                    (!skeleton) ? (
-                        <RealCard />
-                    ) : (
-                        <SkeletonPreviewCard />
-                    )
-                }
-            </Card>
+        <Link href={`/post/${post.id}`}>
+            <a className="w-full h-full">
+                <Card className="hover:bg-muted cursor-pointer transition-colors h-full">
+                    {
+                        (!skeleton) ? (
+                            <RealCard />
+                        ) : (
+                            <SkeletonPreviewCard />
+                        )
+                    }
+                </Card>
+            </a>
         </Link>
-
     );
 }

--- a/frontend/src/components/PostsPreview/PostsPreview.tsx
+++ b/frontend/src/components/PostsPreview/PostsPreview.tsx
@@ -16,7 +16,7 @@ export default function PostsPreview() {
 
   return (
     <>
-      <div id="post-wrap" className="w-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 grid-flow-row place-items-center gap-5 p-5">
+      <div id="post-wrap" className="w-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 grid-flow-row place-content-center place-items-center gap-5 p-5">
         {
           splashPosts && splashPosts.length > 0 ? (
             <ul>

--- a/frontend/src/components/Profile/Profile.tsx
+++ b/frontend/src/components/Profile/Profile.tsx
@@ -1,0 +1,10 @@
+
+export default function Profile() {
+  return (
+    <>
+      <div id="profile-wrap" className="w-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 grid-flow-row place-items-center gap-5 p-5">
+        <h1>Profile</h1>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/Test/Test.tsx
+++ b/frontend/src/components/Test/Test.tsx
@@ -1,0 +1,7 @@
+export default function Test() {
+
+  return (
+    <></>
+  )
+
+}

--- a/frontend/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useEffect, useState } from "react"
+
+type Theme = "dark" | "light" | "system"
+
+type ThemeProviderProps = {
+  children: React.ReactNode
+  defaultTheme?: Theme
+  storageKey?: string
+}
+
+type ThemeProviderState = {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+const initialState: ThemeProviderState = {
+  theme: "system",
+  setTheme: () => null,
+}
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+  storageKey = "vite-ui-theme",
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+  )
+
+  useEffect(() => {
+    const root = window.document.documentElement
+
+    root.classList.remove("light", "dark")
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light"
+
+      root.classList.add(systemTheme)
+      return
+    }
+
+    root.classList.add(theme)
+  }, [theme])
+
+  const value = {
+    theme,
+    setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme)
+      setTheme(theme)
+    },
+  }
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext)
+
+  if (context === undefined)
+    throw new Error("useTheme must be used within a ThemeProvider")
+
+  return context
+}

--- a/frontend/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import { Moon, Sun } from "lucide-react"
+
+import { useTheme } from "@/components/ThemeProvider/ThemeProvider"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export function ModeToggle() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/components/UserPostsHistory/UserPostsHistory.tsx
+++ b/frontend/src/components/UserPostsHistory/UserPostsHistory.tsx
@@ -1,0 +1,12 @@
+import PostsPreview from "../PostsPreview/PostsPreview";
+
+export default function UserPostsHistory() {
+    return (
+        <div className="w-3/4">
+            <p>You've made X posts since creating you account and got a total of Y thumbs up!</p>
+            <p>View Previous Posts:</p>
+            <PostsPreview />
+        </div>
+    )
+
+}

--- a/frontend/src/components/faq/faq.tsx
+++ b/frontend/src/components/faq/faq.tsx
@@ -1,7 +1,7 @@
 export default function faq() {
   return (
     <>
-      <main className="flex flex-col flex-auto flex-wrap justify-center w-1/2 md:w-3/5 max-w-screen-lg space-y-10 *:p-5">
+      <main className="flex flex-col flex-auto place-items-center w-1/2 md:w-3/5 max-w-screen-lg space-y-10 *:p-5">
         <section id="splash-intro" className="w-full *:m-0">
           <h1 className="scroll-m-20 border-b pb-4 text-4xl font-extrabold tracking-tight lg:text-5xl break-words">
             What is this?

--- a/frontend/src/components/faq/faq.tsx
+++ b/frontend/src/components/faq/faq.tsx
@@ -1,0 +1,60 @@
+export default function faq() {
+  return (
+    <>
+      <main className="flex flex-col flex-auto flex-wrap justify-center w-1/2 md:w-3/5 max-w-screen-lg space-y-10 *:p-5">
+        <section id="splash-intro" className="w-full *:m-0">
+          <h1 className="scroll-m-20 border-b pb-4 text-4xl font-extrabold tracking-tight lg:text-5xl break-words">
+            What is this?
+          </h1>
+          <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
+            You may be wondering what Purrcast even is. To describe the goal of Purrcast simply, it's here to serve as a caveman-like weather prediction app, taking
+            rolling averages of the amount of cats laying on their heads in your area to determine if it's going to rain soon.
+          </p>
+          <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
+            For example, imagine 3 of your friends (or just randos) have posted images of their cats sleeping in your area.
+          </p>
+          <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
+            Of those 3 sleepings cats, 2 of them are laying on their heads. This means that there's a 66% - or 2/3 for you math gurus - chance of rain in your area.
+          </p>
+
+          <div id="splash-buttons" className="flex flex-row justify-start w-full mt-8 space-x-4">
+
+          </div>
+        </section>
+
+        <section id="splash-prev-posts" className="w-full">
+          <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
+            What do I post here?
+          </h2>
+          <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
+            Pictures of your cat. I feel like you should have been able to figure that out on your own, but I'm not here to judge.
+          </p>
+        </section>
+
+        <section id="splash-prev-posts" className="w-full">
+          <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0">
+            What kind of cat pictures?
+          </h2>
+          <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
+            Although all cat pics are good cat pics, on Purrcast that is a different story. We're looking for a specific type of cat pic.
+            That is, pictures of sleeping cats only! If you decide to post a photo on Purrcast to help others devolve back to their monolithic roots, you must make sure your cat is asleep in the photo.
+            Otherwise, it will taint the data!
+          </p>
+          <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
+            We do have systems in place to try to keep people from posting a photo of a cat if the cat is not asleep in the image, but we are actually legally obligated to tell you that the creator of this site has an IQ less than 96, so we can't put too much trust into that.
+            Although the systems are there, please do your due diligence and make sure your cat is asleep in the photo before posting. Please report any photos that are not of sleeping cats.
+          </p>
+
+          <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight mt-6">
+            What do we consider <i>sleeping on it's head</i>?
+          </h3>
+          <p className="leading-7 [&:not(:first-child)]:mt-6 break-words">
+            As already mentioned, the means for us predicting what the weather will be like is solely based on whether a cat is sleeping on it's head or not.
+            You may confused as to what we consider a cat sleeping on it's head, so please refer to the examples below for the 3 types of sleeping cats we consider:
+          </p>
+        </section>
+      </main>
+
+    </>
+  );
+}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,203 @@
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import {
+  CheckIcon,
+  ChevronRightIcon,
+  DotFilledIcon,
+} from "@radix-ui/react-icons"
+
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRightIcon className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <DotFilledIcon className="h-4 w-4 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}


### PR DESCRIPTION
Set up routing with wouter framework, just because. It's really easy to work with, small, and somewhat customizable; I'm liking it so far.

Set up routes for:
  - home page(/)
  - login page (/login)
  - logging out [possibly] (/logout)
  - making new posts (/new-post)
  - viewing posts you've made (/profile/posts)
  - viewing a singular post (/post/:post_id
  - your profile, settings, etc (/profile)
  - the faq page (/faq)
  
The next steps is to begin building components to represent the page for each of these routes. 
Currently, the **faq** page, **login** page, **new-post** page have minimal content. The rest have nothing. it will be slow.

The steps thereafter is took hook up to supabase auth for actually signing up/logging in, alongside the geolocation API to populate location data for the user.

And the _almost_ final steps after that will to set up backend API endpoints to handle requests to post, view posts, delete posts, view account details, and log out.

The final jump will be to actively give users predictions for their area on the homepage... This will warrant the creation of a new component TrueHome (or something to indicate a home page for logged in users) where details like this are shown, alongside posts in the area maybe.